### PR TITLE
BASES: Set Padding to Zero on Button Base

### DIFF
--- a/src/SLO/SLO.MobileApp/MainPage.xaml.cs
+++ b/src/SLO/SLO.MobileApp/MainPage.xaml.cs
@@ -1,43 +1,12 @@
 ﻿using Microsoft.Maui.Controls;
-using SLO.MobileApp.Core.Models.Foundations.ShoppingItems;
-using System;
-using System.ComponentModel;
 
 namespace SLO.MobileApp;
 
-public partial class MainPage : ContentPage, INotifyPropertyChanged
+public partial class MainPage : ContentPage
 {
-    private ShoppingItem _shoppingItem;
-
-    public ShoppingItem ShoppingItem
-    {
-        get { return _shoppingItem; }
-        set
-        {
-            _shoppingItem = value;
-            OnPropertyChanged();
-        }
-    }
-
-
-    int count = 0;
 
     public MainPage()
     {
         InitializeComponent();
-
-        ShoppingItem =
-            new ShoppingItem
-            {
-                CreatedAt = DateTime.Now,
-                CreatedBy = Guid.NewGuid(),
-                Description = "Desc",
-                Name = "New",
-                Quantity = 123
-            };
-
-        BindingContext = this;
     }
-
-#nullable enable
 }

--- a/src/SLO/SLO.MobileApp/Views/Bases/ButtonBase.cs
+++ b/src/SLO/SLO.MobileApp/Views/Bases/ButtonBase.cs
@@ -1,7 +1,12 @@
-﻿using Microsoft.Maui.Controls;
+﻿using Microsoft.Maui;
+using Microsoft.Maui.Controls;
 
 namespace SLO.MobileApp.Views.Bases;
 
 public partial class ButtonBase : Button
 {
+    public ButtonBase()
+    {
+        this.Padding = Thickness.Zero;
+    }
 }


### PR DESCRIPTION
Closes #24

# Pull Request Title
Making sure that Padding is set to Zero when initiating the Button Base. The Padding value could still be changed to a desired value, so no breaking change here. 

---

---

## Type of Change
Select all that apply:

- [ ] Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Security Fix
- [ ] CI/CD or Tooling Update
- [ ] Breaking Change
- [ ] Other (explain below)

If this is a **breaking change**, describe the impact and required migration steps.

---

## How Has This Been Tested?
Manual UI Test

- What tests were run? UI Tests
- Any manual testing steps? None
- Any edge cases considered? None

---

## Checklist
- [X] Code follows project style guidelines
- [X] Self-review completed
- [ ] Tests added or updated where necessary
- [ ] Documentation updated if needed
- [x] No new warnings or errors
- [ ] All tests pass successfully

---

## Screenshots
### On Windows
<img width="1422" height="718" alt="Screenshot 2026-04-19 134103" src="https://github.com/user-attachments/assets/b69aa390-9242-4c84-9d77-f4b16dde48e9" />

### On Android
<img width="425" height="959" alt="Screenshot 2026-04-19 134217" src="https://github.com/user-attachments/assets/290de27d-5f77-4809-a17e-160684820ced" />

---
