### PR TITLE
INFRA: Introduce IsFullTextSelectionEnabled in Entry Base

### DIFF
--- a/src/SLO/SLO.MobileApp/Views/Bases/EntryBase.cs
+++ b/src/SLO/SLO.MobileApp/Views/Bases/EntryBase.cs
@@ -1,7 +1,99 @@
 ﻿using Microsoft.Maui.Controls;
+using System.Threading.Tasks;
 
 namespace SLO.MobileApp.Views.Bases;
 
 public partial class EntryBase : Entry
 {
+    public static readonly BindableProperty IsFullTextSelectionEnabledProperty =
+        BindableProperty.Create(
+            propertyName: nameof(IsFullTextSelectionEnabled),
+            returnType: typeof(bool),
+            declaringType: typeof(EntryBase),
+            defaultValue: false,
+            propertyChanged: IsFullTextSelectionEnabledChanged);
+
+    public bool IsFullTextSelectionEnabled
+    {
+        get => (bool)GetValue(IsFullTextSelectionEnabledProperty);
+        set => SetValue(IsFullTextSelectionEnabledProperty, value);
+    }
+
+    protected override void OnHandlerChanging(HandlerChangingEventArgs args)
+    {
+        base.OnHandlerChanging(args);
+
+        if (args.NewHandler is not null)
+        {
+            return;
+        }
+
+        this.Focused -= OnEntryFocusedEvent;
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+
+        if (this.Handler is null)
+        {
+            return;
+        }
+
+        if (IsFullTextSelectionEnabled)
+        {
+            this.Focused += OnEntryFocusedEvent;
+        }
+    }
+
+    private static void IsFullTextSelectionEnabledChanged(
+        BindableObject bindable,
+        object oldValue,
+        object newValue)
+    {
+        if (bindable is not EntryBase entryBase)
+        {
+            return;
+        }
+
+        if (oldValue.Equals(newValue))
+        {
+            return;
+        }
+
+        if ((bool)newValue is false)
+        {
+            entryBase.Focused -= entryBase.OnEntryFocusedEvent;
+
+            return;
+        }
+
+        entryBase.Focused -= entryBase.OnEntryFocusedEvent;
+        entryBase.Focused += entryBase.OnEntryFocusedEvent;
+    }
+
+    private void OnEntryFocusedEvent(object sender, FocusEventArgs e)
+    {
+        if (IsFullTextSelectionEnabled is false)
+        {
+            return;
+        }
+
+        if (sender is not EntryBase entryBase)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(entryBase.Text))
+        {
+            return;
+        }
+
+        _ = Dispatcher.Dispatch(async () =>
+        {
+            await Task.Delay(10);
+            entryBase.CursorPosition = 0;
+            entryBase.SelectionLength = entryBase.Text.Length;
+        });
+    }
 }

--- a/src/SLO/SLO.MobileApp/Views/Controls/NumericEntry.xaml
+++ b/src/SLO/SLO.MobileApp/Views/Controls/NumericEntry.xaml
@@ -12,6 +12,7 @@
             <bases:EntryBase
                 FontAttributes="{TemplateBinding FontAttribute}"
                 FontSize="{TemplateBinding FontSize}"
+                IsFullTextSelectionEnabled="True"
                 Keyboard="Numeric"
                 Placeholder="{TemplateBinding Placeholder}"
                 Text="{TemplateBinding Value}"


### PR DESCRIPTION
Closes #25 

# Pull Request Title
This pull request introduces IsFullTextSelectionEnabled property

---

## Description
The IsFullTextSelectionEnabled property along with OnEntryBaseFocusedEvent allow Full Text Selection when the user taps/clicks the Entry Control, so it is much easier to change values just like in more higher-level control ex. NumericEntry Control.

---

## Type of Change
Select all that apply:

- [X] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Security Fix
- [ ] CI/CD or Tooling Update
- [ ] Breaking Change
- [ ] Other (explain below)

If this is a **breaking change**, describe the impact and required migration steps.

---

## How Has This Been Tested?
Manual UI Tests on both Windows and Android.

- What tests were run? UI Tests
- Any manual testing steps? None
- Any edge cases considered? 
Yes, when changing the IsFullTextSelectionEnabled in XAML while the application is running, the code does:
1. Checks if the new value is false, then just unsubscribes
2. If the new value is true, it unsubscribes first before it subscribes to prevent double subscription to the same event.

---

## Checklist
- [X] Code follows project style guidelines
- [X] Self-review completed
- [ ] Tests added or updated where necessary
- [ ] Documentation updated if needed
- [ ] No new warnings or errors
- [ ] All tests pass successfully

---
